### PR TITLE
fix: import fetch in rss2json util

### DIFF
--- a/server/utils/rss2json.test.ts
+++ b/server/utils/rss2json.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { rss2json } from "./rss2json"
+
+vi.mock("./fetch", () => ({
+  myFetch: vi.fn().mockResolvedValue(`<?xml version="1.0" encoding="UTF-8"?>
+<rss>
+  <channel>
+    <title>Example</title>
+    <description>Example feed</description>
+    <link>https://example.com</link>
+    <item>
+      <title>Item title</title>
+      <description>Item description</description>
+      <link>https://example.com/item</link>
+    </item>
+  </channel>
+</rss>`),
+}))
+
+describe("rss2json", () => {
+  it("parses rss feed into object", async () => {
+    const result = await rss2json("https://example.com/feed")
+    expect(result?.title).toBe("Example")
+    expect(result?.items.length).toBe(1)
+    expect(result?.items[0].title).toBe("Item title")
+  })
+})

--- a/server/utils/rss2json.ts
+++ b/server/utils/rss2json.ts
@@ -1,5 +1,6 @@
 import { XMLParser } from "fast-xml-parser"
 import type { RSSInfo } from "../types"
+import { myFetch } from "./fetch"
 
 export async function rss2json(url: string): Promise<RSSInfo | undefined> {
   if (!/^https?:\/\/[^\s$.?#].\S*/i.test(url)) return


### PR DESCRIPTION
## Summary
- fix rss2json util by importing shared fetch helper
- add regression test for rss2json

## Testing
- `npx vitest run -c vitest.config.ts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a44c26924083309015399095561f55