### PR TITLE
Fix user update logic and documentation typos

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,11 +55,11 @@
 参考 `example.env.server` 文件，本地运行时重命名为 `.env.server` 并填写以下配置：
 
 ```env
-# Github Clien ID
+# Github Client ID
 G_CLIENT_ID=
-# Github Clien Secret
+# Github Client Secret
 G_CLIENT_SECRET=
-# JWT Secret, 通常就用 Clien Secret
+# JWT Secret, 通常就用 Client Secret
 JWT_SECRET=
 # 初始化数据库, 首次运行必须设置为 true，之后可以将其关闭
 INIT_TABLE=true
@@ -76,11 +76,11 @@ ENABLE_CACHE=true
 4. 重新部署生效
 
 ### Docker 部署
-对于 Docker 部署，只需要项目根目录 `docker-compose.yaml` 文件，同一目录下执行
+对于 Docker 部署，只需要项目根目录 `docker-compose.yml` 文件，同一目录下执行
 ```
 docker compose up
 ```
-同样可以通过 `docker-compose.yaml` 配置环境变量。
+同样可以通过 `docker-compose.yml` 配置环境变量。
 
 ## 开发
 > [!Note]

--- a/server/database/user.ts
+++ b/server/database/user.ts
@@ -11,7 +11,7 @@ export class UserTable {
   async init() {
     // Check if we're using MySQL by looking for MySQL environment variables
     const isMySQL = process.env.MYSQL_HOST && process.env.MYSQL_USER && process.env.MYSQL_PASSWORD && process.env.MYSQL_DATABASE
-    
+
     if (isMySQL) {
       // MySQL syntax
       await this.db.prepare(`
@@ -50,7 +50,7 @@ export class UserTable {
     const u = await this.getUser(id)
     const now = Date.now()
     const isMySQL = process.env.MYSQL_HOST && process.env.MYSQL_USER && process.env.MYSQL_PASSWORD && process.env.MYSQL_DATABASE
-    
+
     if (!u) {
       if (isMySQL) {
         // MySQL syntax - use ON DUPLICATE KEY UPDATE
@@ -62,9 +62,11 @@ export class UserTable {
           .run(id, email, "", type, now, now)
       }
       logger.success(`add user ${id}`)
-    } else if (u.email !== email && u.type !== type) {
-      await this.db.prepare(`UPDATE user SET email = ?, updated = ? WHERE id = ?`).run(email, now, id)
-      logger.success(`update user ${id} email`)
+    } else if (u.email !== email || u.type !== type) {
+      await this.db
+        .prepare(`UPDATE user SET email = ?, type = ?, updated = ? WHERE id = ?`)
+        .run(email, type, now, id)
+      logger.success(`update user ${id}`)
     } else {
       logger.info(`user ${id} already exists`)
     }

--- a/test/common.test.ts
+++ b/test/common.test.ts
@@ -1,5 +1,8 @@
-import { it } from "vitest"
+import { describe, expect, it } from "vitest"
+import { relativeTime } from "../shared/utils"
 
-it("test", () => {
-  //
+describe("shared utils", () => {
+  it("relativeTime returns 刚刚 for current timestamp", () => {
+    expect(relativeTime(Date.now())).toBe("刚刚")
+  })
 })


### PR DESCRIPTION
## Summary
- fix GitHub OAuth env variable typos and docker-compose filename in Chinese README
- correct user update logic to refresh email and type independently
- add basic test for `relativeTime` utility

## Testing
- `npx eslint server/database/user.ts test/common.test.ts README.zh-CN.md && echo LINT_OK`
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_68a44c26ad388330858879cb31f755ef