### PR TITLE
docs: Configure default PR target to yknothing/today-news

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# 贡献指南 / Contributing Guide
+
+感谢你对本项目的关注！
+
+## Pull Request 流程 / PR Process
+
+### 重要说明 / Important Notice
+
+**本项目的所有 Pull Request 应该提交到 `yknothing/today-news` 仓库，而不是上游的原始仓库。**
+
+**All Pull Requests for this project should be submitted to the `yknothing/today-news` repository, not the upstream original repository.**
+
+### 创建 PR 时的注意事项 / Notes When Creating PR
+
+当你在 GitHub 上创建 Pull Request 时，请注意以下几点：
+
+1. **检查目标仓库**：确保 base repository 选择的是 `yknothing/today-news`
+2. **检查目标分支**：通常应该选择 `main` 分支作为目标分支
+3. **填写 PR 模板**：请按照 PR 模板的要求填写相关信息
+
+### 开发流程 / Development Workflow
+
+1. Fork 本仓库（如果还没有 fork）
+2. 克隆你的 fork 到本地：
+   ```bash
+   git clone https://github.com/your-username/today-news.git
+   cd today-news
+   ```
+
+3. 创建新的功能分支：
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+4. 进行开发和测试
+
+5. 提交更改：
+   ```bash
+   git add .
+   git commit -m "描述你的更改"
+   git push origin feature/your-feature-name
+   ```
+
+6. 在 GitHub 上创建 Pull Request：
+   - **重要**：选择 base repository 为 `yknothing/today-news`
+   - 选择 base 分支为 `main`（或其他目标分支）
+   - 选择 compare 分支为你的功能分支
+
+### 代码规范 / Code Standards
+
+- 遵循项目现有的代码风格
+- 运行 `npm run lint` 检查代码规范
+- 确保所有测试通过 `npm run test`
+
+### 问题反馈 / Issue Reporting
+
+如果你发现 bug 或有功能建议，请在 `yknothing/today-news` 仓库中创建 issue。
+
+## 联系方式 / Contact
+
+如有任何问题，欢迎通过 issue 或其他方式联系维护者。

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Pull Request
+
+### 重要提示 / Important Notice
+
+**请确保此 PR 的目标仓库是 `yknothing/today-news`，而不是上游仓库。**
+
+**Please ensure that the base repository for this PR is `yknothing/today-news`, not the upstream repository.**
+
+---
+
+### 描述 / Description
+
+<!-- 请描述本次 PR 的主要变更内容 -->
+<!-- Please describe the main changes in this PR -->
+
+### 变更类型 / Type of Change
+
+- [ ] Bug 修复 / Bug fix
+- [ ] 新功能 / New feature
+- [ ] 功能改进 / Enhancement
+- [ ] 文档更新 / Documentation update
+- [ ] 代码重构 / Code refactoring
+- [ ] 其他 / Other
+
+### 测试 / Testing
+
+<!-- 请描述如何测试这些变更 -->
+<!-- Please describe how to test these changes -->
+
+### 检查清单 / Checklist
+
+- [ ] 代码已经过本地测试 / Code has been tested locally
+- [ ] 已确认 PR 目标仓库为 yknothing/today-news / Confirmed PR targets yknothing/today-news
+- [ ] 遵循项目代码规范 / Follows project code style
+- [ ] 相关文档已更新 / Related documentation has been updated


### PR DESCRIPTION
- Add PR template to remind contributors to target yknothing/today-news
- Add CONTRIBUTING guide with detailed PR workflow instructions
- Ensure all PRs default to this fork instead of upstream repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)