### PR TITLE
Add Playwright E2E baseline and stable footer test id

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "release": "bumpp",
     "prepare": "simple-git-hooks",
     "log": "wrangler pages deployment tail --project-name newsnow",
-    "test": "vitest -c vitest.config.ts"
+    "test": "vitest -c vitest.config.ts",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.5.0",
@@ -68,6 +69,7 @@
     "@napi-rs/pinyin": "^1.7.5",
     "@ourongxing/eslint-config": "3.2.3-beta.6",
     "@ourongxing/tsconfig": "^0.0.4",
+    "@playwright/test": "^1.52.0",
     "@rollup/pluginutils": "^5.1.4",
     "@tanstack/react-query": "^5.66.11",
     "@tanstack/router-devtools": "^1.112.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,19 @@
+import process from "node:process"
+import { defineConfig } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./test/e2e",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "pnpm dev -- --host 127.0.0.1 --port 4173",
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -60,7 +60,10 @@ function RootComponent() {
         >
           <Outlet />
         </main>
-        <footer className="py-6 flex flex-col items-center justify-center text-sm text-neutral-500 font-mono">
+        <footer
+          className="py-6 flex flex-col items-center justify-center text-sm text-neutral-500 font-mono"
+          data-testid="app-footer"
+        >
           <Footer />
         </footer>
       </GlobalOverlayScrollbar>

--- a/test/e2e/home.spec.ts
+++ b/test/e2e/home.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "@playwright/test"
+
+test("home page shows footer and license", async ({ page }) => {
+  await page.goto("/")
+
+  const footer = page.getByTestId("app-footer")
+  await expect(footer).toContainText("NewsNow")
+  await expect(page.getByRole("link", { name: "MIT LICENSE" })).toBeVisible()
+})


### PR DESCRIPTION
### Motivation

- Establish an automated E2E testing baseline for the app so UI-level regressions can be caught early.  
- Provide a stable selector for tests by exposing a `data-testid` on the app footer for reliable assertions.  
- Add minimal Playwright configuration and a simple smoke test to validate the home page and license link.  
- Keep changes small and focused to avoid over-design while enabling future E2E expansion.

### Description

- Added `playwright.config.ts` with server startup, base URL, timeouts, and trace settings.  
- Added a simple E2E test `test/e2e/home.spec.ts` that checks the footer displays `NewsNow` and that the `MIT LICENSE` link is visible.  
- Exposed a stable footer selector by adding `data-testid="app-footer"` to the footer in `src/routes/__root.tsx`.  
- Updated `package.json` to add a `test:e2e` script and declared `@playwright/test` as a dev dependency, and adjusted imports (`process` in `playwright.config.ts`) to satisfy lint rules.

### Testing

- Pre-commit linting (`eslint --fix`) ran as part of the commit flow and passed after fixing the `process` import.  
- Attempted to install dependencies with `pnpm install`, but installation failed due to a `403` from the npm registry which prevented installing `@playwright/test`.  
- Because the install failed, `playwright test` was not executed and no E2E tests were run.  
- No changes were made to the existing unit test setup (`vitest`) and existing tests were not run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69553f3ef2848330b436207f176074e2)